### PR TITLE
Improve array coercion logic

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -19,6 +19,7 @@ var defaults = {
     delimiter: '&',
     depth: 5,
     duplicates: 'combine',
+    forceArrays: false,
     ignoreQueryPrefix: false,
     interpretNumericEntities: false,
     parameterLimit: 1000,
@@ -294,6 +295,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         // eslint-disable-next-line no-implicit-coercion, no-extra-parens
         depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
         duplicates: duplicates,
+        forceArrays: opts.forceArrays === true,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
@@ -303,6 +305,59 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling,
         throwOnLimitExceeded: typeof opts.throwOnLimitExceeded === 'boolean' ? opts.throwOnLimitExceeded : false
     };
+};
+
+/* eslint no-param-reassign: 0 */
+var maybeCoerceToArray = function maybeCoerceToArray(obj, options) {
+    if (options.forceArrays !== true || obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    if (isArray(obj)) {
+        for (var i = 0; i < obj.length; ++i) {
+            obj[i] = maybeCoerceToArray(obj[i], options);
+        }
+        return obj;
+    }
+
+    var keys = Object.keys(obj);
+    var allNumeric = true;
+    var numericKeys = [];
+    for (var j = 0; j < keys.length; ++j) {
+        if ((/^(?:0|[1-9]\d*)$/).test(keys[j])) {
+            numericKeys.push(parseInt(keys[j], 10));
+        } else {
+            allNumeric = false;
+            j = keys.length; // The eslint settings do not allow break;
+        }
+    }
+
+    if (allNumeric) {
+        numericKeys.sort(function (a, b) {
+            return a - b;
+        });
+        for (var k = 0; k < numericKeys.length && allNumeric; ++k) {
+            if (numericKeys[k] !== k) {
+                allNumeric = false;
+                k = numericKeys.length; // The eslint settings do not allow break;
+            }
+        }
+
+        if (allNumeric && (options.forceArrays || numericKeys.length - 1 <= options.arrayLimit)) {
+            var array = [];
+            for (var l = 0; l < numericKeys.length; ++l) {
+                array[l] = maybeCoerceToArray(obj[numericKeys[l]], options);
+            }
+            return array;
+        }
+    }
+
+    for (var m = 0; m < keys.length; ++m) {
+        var key = keys[m];
+        obj[key] = maybeCoerceToArray(obj[key], options);
+    }
+
+    return obj;
 };
 
 module.exports = function (str, opts) {
@@ -328,5 +383,5 @@ module.exports = function (str, opts) {
         return obj;
     }
 
-    return utils.compact(obj);
+    return maybeCoerceToArray(utils.compact(obj), options);
 };

--- a/test/parse.js
+++ b/test/parse.js
@@ -506,6 +506,23 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('coerces numeric object keys to arrays with forceArrays', function (st) {
+        st.deepEqual(
+            qs.parse('a[0]=b&a[1]=c', { arrayLimit: 0, forceArrays: true }),
+            { a: ['b', 'c'] }
+        );
+
+        st.deepEqual(
+            qs.parse(
+                'WHERE[property_units.unit_id][IN][0]=a&WHERE[property_units.unit_id][IN][1]=b',
+                { arrayLimit: 0, forceArrays: true }
+            ),
+            { WHERE: { 'property_units.unit_id': { IN: ['a', 'b'] } } }
+        );
+
+        st.end();
+    });
+
     t.test('allows for query string prefix', function (st) {
         st.deepEqual(qs.parse('?foo=bar', { ignoreQueryPrefix: true }), { foo: 'bar' });
         st.deepEqual(qs.parse('foo=bar', { ignoreQueryPrefix: true }), { foo: 'bar' });


### PR DESCRIPTION
## Summary
- add `forceArrays` option to selectively coerce objects with contiguous numeric keys into arrays
- implement recursive `maybeCoerceToArray` in parsing logic
- add tests demonstrating `forceArrays` behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f1b736d148325a3197f6eefcc475d